### PR TITLE
-e VNC_SCREEN_SIZE to set sizes of VNC & Chrome; Updated to Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,31 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 LABEL maintainer="Tomohisa Kusano <siomiz@gmail.com>"
 
+ENV VNC_SCREEN_SIZE 1024x768
+
 COPY copyables /
 
-ADD https://dl.google.com/linux/linux_signing_key.pub /tmp/
-
-RUN apt-key add /tmp/linux_signing_key.pub \
-	&& apt-get update \
-	&& apt-get install -y \
-	google-chrome-stable \
-	chrome-remote-desktop \
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+	gdebi \
+	gnupg2 \
 	fonts-takao \
 	pulseaudio \
 	supervisor \
 	x11vnc \
-	fluxbox \
-	&& apt-get clean \
+	fluxbox
+
+ADD https://dl.google.com/linux/linux_signing_key.pub \
+	https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+	https://dl.google.com/linux/direct/chrome-remote-desktop_current_amd64.deb \
+	/tmp/
+
+RUN apt-key add /tmp/linux_signing_key.pub \
+	&& gdebi --non-interactive /tmp/google-chrome-stable_current_amd64.deb \
+	&& gdebi --non-interactive /tmp/chrome-remote-desktop_current_amd64.deb
+
+RUN apt-get clean \
 	&& rm -rf /var/cache/* /var/log/apt/* /var/lib/apt/lists/* /tmp/* \
 	&& useradd -m -G chrome-remote-desktop,pulse-access chrome \
 	&& usermod -s /bin/bash chrome \

--- a/copyables/entrypoint.sh
+++ b/copyables/entrypoint.sh
@@ -22,4 +22,10 @@ if [[ "$VNC_PASSWORD" != "" ]]; then
   export X11VNC_AUTH="-passwd $VNC_PASSWORD"
 fi
 
+# set sizes for both VNC screen & Chrome window
+: ${VNC_SCREEN_SIZE:='1024x768'}
+IFS='x' read SCREEN_WIDTH SCREEN_HEIGHT <<< "${VNC_SCREEN_SIZE}"
+export VNC_SCREEN="${SCREEN_WIDTH}x${SCREEN_HEIGHT}x24"
+export CHROME_WINDOW_SIZE="${SCREEN_WIDTH},${SCREEN_HEIGHT}"
+
 exec "$@"

--- a/copyables/etc/apt/sources.list.d/google-chrome.list
+++ b/copyables/etc/apt/sources.list.d/google-chrome.list
@@ -1,2 +1,0 @@
-deb http://dl.google.com/linux/chrome/deb/ stable main
-deb http://dl.google.com/linux/chrome-remote-desktop/deb/ stable main

--- a/copyables/etc/supervisor/conf.d/supervisord.conf
+++ b/copyables/etc/supervisor/conf.d/supervisord.conf
@@ -2,13 +2,13 @@
 nodaemon=true
 
 [program:xvfb]
-command=/usr/bin/Xvfb :1 -screen 0 1024x768x24 +extension RANDR
+command=/usr/bin/Xvfb :1 -screen 0 %(ENV_VNC_SCREEN)s +extension RANDR
 autorestart=true
 priority=100
 
 [program:chrome]
 environment=HOME="/home/chrome",DISPLAY=":1",USER="chrome"
-command=/opt/google/chrome/chrome --user-data-dir --no-sandbox --window-position=0,0 --window-size=1024,768 --force-device-scale-factor=1
+command=/opt/google/chrome/chrome --user-data-dir --no-sandbox --window-position=0,0 --window-size=%(ENV_CHROME_WINDOW_SIZE)s --force-device-scale-factor=1
 user=chrome
 autorestart=true
 priority=200


### PR DESCRIPTION
Added optional `-e VNC_SCREEN_SIZE=1024x768` (takes `<WIDTH>x<HEIGHT>`) to set VNC screen size and Chrome window size.
Closes #9.