### PR TITLE
Allow command line options to be passed at runtime

### DIFF
--- a/copyables/crd-session
+++ b/copyables/crd-session
@@ -1,2 +1,2 @@
 rm -rf /home/chrome/.config/chrome-remote-desktop/chrome-profile/Singleton*
-exec /opt/google/chrome/chrome --no-sandbox --start-maximized --force-device-scale-factor=1 --use-system-title-bar
+exec /opt/google/chrome/chrome --no-sandbox --start-maximized --force-device-scale-factor=1 --use-system-title-bar ${CHROME_OPTS}

--- a/copyables/entrypoint.sh
+++ b/copyables/entrypoint.sh
@@ -28,4 +28,6 @@ IFS='x' read SCREEN_WIDTH SCREEN_HEIGHT <<< "${VNC_SCREEN_SIZE}"
 export VNC_SCREEN="${SCREEN_WIDTH}x${SCREEN_HEIGHT}x24"
 export CHROME_WINDOW_SIZE="${SCREEN_WIDTH},${SCREEN_HEIGHT}"
 
+export CHROME_OPTS="${CHROME_OPTS_OVERRIDE:- --user-data-dir --no-sandbox --window-position=0,0 --force-device-scale-factor=1}"
+
 exec "$@"

--- a/copyables/etc/supervisor/conf.d/supervisord.conf
+++ b/copyables/etc/supervisor/conf.d/supervisord.conf
@@ -8,7 +8,7 @@ priority=100
 
 [program:chrome]
 environment=HOME="/home/chrome",DISPLAY=":1",USER="chrome"
-command=/opt/google/chrome/chrome --user-data-dir --no-sandbox --window-position=0,0 --window-size=%(ENV_CHROME_WINDOW_SIZE)s --force-device-scale-factor=1
+command=/opt/google/chrome/chrome --window-size=%(ENV_CHROME_WINDOW_SIZE)s %(ENV_CHROME_OPTS)s
 user=chrome
 autorestart=true
 priority=200


### PR DESCRIPTION
By setting the environmental variable "CHROME_OPTS_OVERRIDE" you can pass whatever options you want to the chrome process.