### PR TITLE
add --disable-dev-shm-usage to CHROME_OPTS

### DIFF
--- a/copyables/entrypoint.sh
+++ b/copyables/entrypoint.sh
@@ -28,6 +28,6 @@ IFS='x' read SCREEN_WIDTH SCREEN_HEIGHT <<< "${VNC_SCREEN_SIZE}"
 export VNC_SCREEN="${SCREEN_WIDTH}x${SCREEN_HEIGHT}x24"
 export CHROME_WINDOW_SIZE="${SCREEN_WIDTH},${SCREEN_HEIGHT}"
 
-export CHROME_OPTS="${CHROME_OPTS_OVERRIDE:- --user-data-dir --no-sandbox --window-position=0,0 --force-device-scale-factor=1}"
+export CHROME_OPTS="${CHROME_OPTS_OVERRIDE:- --user-data-dir --no-sandbox --window-position=0,0 --force-device-scale-factor=1 --disable-dev-shm-usage}"
 
 exec "$@"


### PR DESCRIPTION
Docker by default only gives 64MB of `/dev/shm` to containers.
While it's possible to have users specify `--shm-size` on `docker run`
here we are disabling the usage of `/dev/shm` by Chrome for simplicity.

Fixes #15.

https://stackoverflow.com/questions/56218242/headless-chromium-on-docker-fails